### PR TITLE
expanded rule fix

### DIFF
--- a/Custom.css
+++ b/Custom.css
@@ -83,7 +83,7 @@ Mac:
 }
 
 /* expand style */
-#elements-content .parent.expande {
+#elements-content .parent.expanded {
 	background: #f1f1f1;
 }
 


### PR DESCRIPTION
Small typo in rule for #elements-content .parent.expanded (missing final 'd')
